### PR TITLE
Remove ca-certificates in the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Based off of https://github.com/tembo-io/pgmq/blob/main/images/pgmq-pg/Dockerfile
 ARG PG_MAJOR_VERSION=16
 
-FROM postgres:${PG_MAJOR_VERSION}-bookworm as build
+FROM postgres:${PG_MAJOR_VERSION}-bookworm AS build
 
 ARG PG_MAJOR_VERSION=16
 
@@ -35,10 +35,5 @@ ARG PG_MAJOR_VERSION=16
 
 COPY --from=build /usr/share/postgresql/${PG_MAJOR_VERSION}/extension /usr/share/postgresql/${PG_MAJOR_VERSION}/extension
 COPY --from=build /usr/lib/postgresql/${PG_MAJOR_VERSION}/lib /usr/lib/postgresql/${PG_MAJOR_VERSION}/lib
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
 
 USER postgres


### PR DESCRIPTION
Remove ca-certificates from the final Docker image. It is not needed.

Resolves #40.